### PR TITLE
Update 'npm install' to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@
 ```console
 $ git clone git@github.com:bloodyowl/react-boilerplate.git
 $ cd react-boilerplate
+$ npm install
 ```
 
 ## dev mode


### PR DESCRIPTION
add `npm install` to the bootstrapping workflow.

but errors exist:

```
958 error notarget No compatible version found: react-router@'git@github.com:rackt/react-router#0.13-compat'
958 error notarget Valid install targets:
958 error notarget ["0.0.0","0.0.1","0.4.0","0.4.1","0.4.2","0.5.0","0.5.1","0.5.2","0.5.3","0.6.0","0.6.1","0.7.0","0.8.0","0.9.0","0.9.1","0.9.2","0.9.3","0.9.4","0.9.5","0.10.0","0.10.1","0.10.2","0.11.0","0.11.1","0.11.2","0.11.3","0.11.4","0.11.5","0.11.6","0.12.0","0.12.1","0.12.2","0.12.3","0.12.4"]
958 error notarget
958 error notarget This is most likely not a problem with npm itself.
958 error notarget In most cases you or one of your dependencies are requesting
958 error notarget a package version that doesn't exist.
959 error System Linux 3.13.0-46-generic
960 error command "/usr/local/bin/node" "/usr/local/bin/npm" "install"
961 error cwd ./react-boilerplate
962 error node -v v0.11.13
963 error npm -v 1.4.9
964 error code ETARGET
```
